### PR TITLE
Fix-deprecated-function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the user gets to the bottom of each article. URLs will be changed in the address
 
 ### Log:
 **1.2**
-- Update tested version of WP Core to 6.0.2
+- Update tested version of WP Core to 6.3.1
 - Replaced deprecated wp_localize_script function
 - Removed internal tracking code
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ the user gets to the bottom of each article. URLs will be changed in the address
 
 **assets/** - Contains **JS**, **SCSS** and compiled **CSS** files used by the plugin
 
-**Instalation guide:**
+**Installation guide:**
 
-**A)** Standart WordPress installation.
+**A)** Standard WordPress installation.
 
 **B)** Put the plugin folder (clone it) into the **wp-content/plugins/** folder.
 
@@ -21,5 +21,13 @@ the user gets to the bottom of each article. URLs will be changed in the address
 **Note:** The plugin is designed to work with every standart WordPress theme, but in order for the plugin to work with custom developed templates it may need a bit of touches.
 
 ### Log:
-**1.1** - Update tested version of WP Core to 6.0.2
-**1.0** - Release
+**1.2**
+- Update tested version of WP Core to 6.0.2
+- Replaced deprecated wp_localize_script function
+- Removed internal tracking code
+
+**1.1**
+- Update tested version of WP Core to 6.0.2
+
+**1.0**
+- Release

--- a/isrp.php
+++ b/isrp.php
@@ -2,8 +2,8 @@
 /*
 Plugin Name: Infinite Scroll Random Post
 Description: This plugin will add Infinite Scroll with Random Posts at the end of each Post Single Page.
-Version: 1.0
-Author: GeroNikolov
+Version: 1.2
+Author: GeroNikolov, dylanfetch
 Author URI: https://geronikolov.com
 License: GPLv2
 */
@@ -14,11 +14,8 @@ class ISRP_LL {
 
     function __construct() {
         // Init Setup Variables
-        $this->_ASSETS_VERSION = "1.0";
+        $this->_ASSETS_VERSION = "1.2";
 
-        // Register Plugin Activation Hook
-        register_activation_hook( __FILE__, array( $this, "isrp_ll_prep_db" ) );
-        
         // Register needed assets
         add_action( "wp_enqueue_scripts", array( $this, "isrp_ll_register_assets" ) );
 
@@ -26,46 +23,6 @@ class ISRP_LL {
         add_action( "wp_ajax_isrp_ll_get_post", array( $this, "isrp_ll_get_post" ) );
         add_action( "wp_ajax_nopriv_isrp_ll_get_post", array( $this, "isrp_ll_get_post" ) );
 
-        // Register Internal Tracking
-        add_action( "wp_footer", array( $this, "isrp_ll_internal_tracking" ) );
-    }
-
-    function isrp_ll_prep_db() {
-        global $wpdb;
-
-        // Create Unique Visits Tracker
-        $isrp_tracker_unique = $wpdb->prefix ."isrp_tracker_unique";
-		if( $wpdb->get_var( "SHOW TABLES LIKE '$isrp_tracker_unique'" ) != $isrp_tracker_unique ) {
-			$charset_collate = $wpdb->get_charset_collate();
-			$sql_ = "
-			CREATE TABLE $isrp_tracker_unique (
-                id INT NOT NULL AUTO_INCREMENT,
-				ip VARCHAR(255),
-                url VARCHAR(255),
-                browser_type VARCHAR(255),
-                last_visit_date DATETIME DEFAULT CURRENT_TIMESTAMP,
-				PRIMARY KEY(id)
-			) $charset_collate;
-			";
-			require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
-            dbDelta( $sql_ );
-            
-            // Set Page ID Index
-            $indexing_sql = "CREATE INDEX page_id ON $isrp_tracker_unique (page_id);";
-            $index_status = $wpdb->query( $indexing_sql );
-
-            // Set IP Index
-            $indexing_sql = "CREATE INDEX ip ON $isrp_tracker_unique (ip);";
-            $index_status = $wpdb->query( $indexing_sql );
-            
-            // Set URL Index
-            $indexing_sql = "CREATE INDEX url ON $isrp_tracker_unique (url);";
-            $index_status = $wpdb->query( $indexing_sql );
-            
-            // Set Browser Type Index
-            $indexing_sql = "CREATE INDEX browser_type ON $isrp_tracker_unique (browser_type);";
-			$index_status = $wpdb->query( $indexing_sql );
-        }
     }
 
     function isrp_ll_register_assets() {
@@ -74,7 +31,7 @@ class ISRP_LL {
             wp_enqueue_script( "isrp_ll_public_js", plugins_url( "/assets/public.js" , __FILE__ ), array( "jquery" ), $this->_ASSETS_VERSION, true );
             wp_enqueue_style( "isrp_ll_public_css", plugins_url( "/assets/public.css", __FILE__ ), array(), $this->_ASSETS_VERSION, "screen" );
 
-            wp_localize_script( "isrp_ll_public_js", "isrpLLAjaxURL", admin_url( "admin-ajax.php" ) );
+            wp_add_inline_script( "isrp_ll_public_js", 'var isrpLLAjaxURL = "' . admin_url( "admin-ajax.php" ) . '";', 'before' );
         }
     }
 
@@ -113,63 +70,6 @@ class ISRP_LL {
         return $result;
     }
 
-    function isrp_ll_internal_tracking() {
-        $this->isrp_ll_set_track();
-    }
-
-    // Internal Tracking Method is a separated method in case we want to reuse it on different place than the wp_footer hook.
-    function isrp_ll_set_track() {
-        global $wpdb;
-        $isrp_tracker_unique = $wpdb->prefix ."isrp_tracker_unique";
-        $tracking = new stdClass;
-        $tracking->url = isset( $_SERVER[ "REDIRECT_URL" ] ) ? $_SERVER[ "REDIRECT_URL" ] : $_SERVER[ "REQUEST_URI" ];
-        $tracking->ip = $_SERVER[ "REMOTE_ADDR" ];
-        $tracking->user_agent = $_SERVER[ "HTTP_USER_AGENT" ];
-
-        // Check if page was visited already
-        $sql_ = $wpdb->prepare( 
-            "SELECT * FROM $isrp_tracker_unique WHERE ip=%s AND url=%s AND browser_type=%s LIMIT 1", 
-            array(
-                $tracking->ip,
-                $tracking->url,
-                $tracking->user_agent
-            )
-        );
-        $results_ = $wpdb->get_results( $sql_, OBJECT );
-
-        if ( empty( $results_ ) ) { // That's a new visit
-            $wpdb->insert(
-                $isrp_tracker_unique,
-                array(
-                    "ip" => $tracking->ip,
-                    "url" => $tracking->url,
-                    "browser_type" => $tracking->user_agent
-                ),
-                array(
-                    "%s",
-                    "%s",
-                    "%s"
-                )
-            );
-        } else { // It's an already existing visit, we shall update the last_visit_date
-            $current_date = date( "Y-m-d H:i:s" );
-            $wpdb->update(
-                $isrp_tracker_unique,
-                array(
-                    "last_visit_date" => $current_date
-                ),
-                array(
-                    "id" => $results_[ 0 ]->id
-                ),
-                array(
-                    "%s"
-                ),
-                array(
-                    "%d"
-                )
-            );
-        }
-    }
 }
 
 $ISRP_LL = new ISRP_LL();

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Infinite Scroll Random Post ===
-Contributors: GeroNikolov
+Contributors: GeroNikolov, dylanfetch
 Donate link: https://geronikolov.com/
 Tags: Open Source, Infinite Scroll, Random Post, Lazy Load, Lazy Loading, Listing
 Requires at least: 3.0.1
-Tested up to: 6.0.2
-Stable tag: 1.
+Tested up to: 6.3.1
+Stable tag: 1.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,6 +33,13 @@ Check it <a href="https://geronikolov.com/escaping-the-recession-in-life/" targe
 
 <strong>Log:</strong>
 <ul>
+
+    <li>1.2 - Update tested version of WP Core to 6.3.1
+        <ul>
+            <li>Replaced deprecated wp_localize_script function</li>
+            <li>Removed internal tracking code</li>
+        </ul>
+    </li>
     <li>1.1 - Update tested version of WP Core to 6.0.2</li>
     <li>1.0 - Release</li>
 </ul>


### PR DESCRIPTION
- Update tested WP Core version to 6.3.1
- Update readme.txt and readme.md
- Replace deprecated wp_localize_script function with wp_add_inline_script
- Remove internal tracking code.
     - The tracking code adds database tables and creates a database hit on each page load, but I don't see anywhere that the tracking data is used, nor where it can be accessed. I don't think the internal tracking code needs to be included in this function